### PR TITLE
#28/Add ChangePasswordRequest DTO for password updates

### DIFF
--- a/Infrastructure/Dtos/ChangePasswordRequest.cs
+++ b/Infrastructure/Dtos/ChangePasswordRequest.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+namespace Infrastructure.Dtos;
+
+public class ChangePasswordRequest
+{
+	[Required(ErrorMessage = "Du måste ange ditt nuvarande lösenord.")]
+	[DataType(DataType.Password)]
+	public string CurrentPassword { get; set; } = null!;
+
+	[Required(ErrorMessage = "Du måste ange ett nytt lösenord.")]
+	[DataType(DataType.Password)]
+	[RegularExpression(@"^(?=.*\d).{6,}$",
+		ErrorMessage = "Lösenordet måste vara minst 6 tecken och innehålla minst en siffra.")]
+	public string NewPassword { get; set; } = null!;
+
+	[Required(ErrorMessage = "Bekräfta ditt nya lösenord.")]
+	[DataType(DataType.Password)]
+	[Compare("NewPassword", ErrorMessage = "Lösenorden matchar inte.")]
+	public string ConfirmNewPassword { get; set; } = null!;
+}


### PR DESCRIPTION
###  **Summary (what I changed)**

**Added Infrastructure/Dtos/ChangePasswordRequest.cs with:**
CurrentPassword (required)
NewPassword (required, min 6 chars & at least one digit — matches Identity settings)
ConfirmNewPassword (required, [Compare("NewPassword")])
Regex used: ^(?=.*\d).{6,}$ to align with Password.RequiredLength = 6 and Password.RequireDigit = true.

### **Why**

Prepare the API for a secure, authenticated “change password” flow without relying on email.
Keep validation consistent with current Identity password policy to avoid mismatches between model validation and server rules.

### **Impact on development**

No breaking changes and no DB changes.
Controllers/services can now implement ChangePasswordAsync using this DTO (UserManager.ChangePasswordAsync), pulling the user from claims.
Improves UX with clear validation errors before hitting Identity.