### PR TITLE
#P42/29 Add authenticated Change Password endpoint (DTO, service, controller)Add ChangePassword feature

### DIFF
--- a/Infrastructure/Interfaces/IAuthService.cs
+++ b/Infrastructure/Interfaces/IAuthService.cs
@@ -9,4 +9,6 @@ public interface IAuthService
 
     Task<AuthServiceResult> LogoutAsync();
     Task<AuthServiceResult> LoginAsync(LoginRequest request);
+
+    Task<AuthServiceResult> ChangePasswordAsync(string userId, ChangePasswordRequest request);
 }

--- a/Infrastructure/Services/AuthService.cs
+++ b/Infrastructure/Services/AuthService.cs
@@ -57,8 +57,8 @@ public class AuthService(UserManager<ApplicationUser> userManager,
         var result = await _signInManager.PasswordSignInAsync(
          user,
          request.Password,
-         isPersistent: false,      
-         lockoutOnFailure: false); 
+         isPersistent: false,
+         lockoutOnFailure: false);
 
         if (result.Succeeded)
             return new AuthServiceResult { Succeeded = true, Message = "Login successful" };
@@ -79,5 +79,26 @@ public class AuthService(UserManager<ApplicationUser> userManager,
             Succeeded = true,
             Message = "Signed out"
         };
+    }
+
+    public async Task<AuthServiceResult> ChangePasswordAsync(string userId, ChangePasswordRequest request)
+    {
+        if (request.NewPassword != request.ConfirmNewPassword)
+            return new AuthServiceResult { Succeeded = false, Error = "Passwords do not match." };
+
+        var user = await _userManager.FindByIdAsync(userId);
+        if (user is null)
+            return new AuthServiceResult { Succeeded = false, Error = "User not found." };
+
+        var result = await _userManager.ChangePasswordAsync(user, request.CurrentPassword, request.NewPassword);
+        if (!result.Succeeded)
+        {
+            var errorMessage = string.Join("; ", result.Errors.Select(e => $"{e.Code}: {e.Description}"));
+            return new AuthServiceResult { Succeeded = false, Error = errorMessage };
+        }
+
+        await _signInManager.RefreshSignInAsync(user);
+
+        return new AuthServiceResult { Succeeded = true, Message = "Password changed successfully." };
     }
 }

--- a/authsystem/Controllers/AuthController.cs
+++ b/authsystem/Controllers/AuthController.cs
@@ -1,6 +1,7 @@
 ﻿using Data.Entities;
 using Infrastructure.Dtos;
 using Infrastructure.Interfaces;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -55,5 +56,19 @@ public class AuthController(IAuthService authService, SignInManager<ApplicationU
             return StatusCode(500, result.Error);
 
         return Ok("Logged out successfully");
+    }
+
+    [Authorize]
+    [HttpPost("change-password")]
+    public async Task<IActionResult> ChangePassword(ChangePasswordRequest request)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        var userId = _userManager.GetUserId(User);
+
+        if (string.IsNullOrEmpty(userId)) return Unauthorized();
+
+        var result = await _authService.ChangePasswordAsync(userId, request);
+        return result.Succeeded ? Ok(result.Message) : BadRequest(new { error = result.Error });
     }
 }

--- a/authsystem/Program.cs
+++ b/authsystem/Program.cs
@@ -13,6 +13,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 
 builder.Services.AddControllers();
+
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
 
@@ -86,6 +87,8 @@ if (app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 
 app.UseCors("spa");
+
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();


### PR DESCRIPTION
### **Summary**

Implements a complete “change password” flow for signed-in users:
New DTO ChangePasswordRequest (currentPassword, newPassword, confirmNewPassword)
Service method ChangePasswordAsync(userId, request) using UserManager.ChangePasswordAsync(...) and SignInManager.RefreshSignInAsync(...).
Controller endpoint POST /api/auth/change-password with [Authorize] that resolves userId from claims and returns 200 OK on success or 400 with { error } on failure.

### **Changes**

Infrastructure/Dtos/ChangePasswordRequest.cs – adds request model and validation (min 6 chars + at least one digit; confirm must match).

Infrastructure/Interfaces/IAuthService.cs – adds Task<AuthServiceResult> ChangePasswordAsync(string userId, ChangePasswordRequest request);

Infrastructure/Services/AuthService.cs – implements change password logic, collects Identity errors, refreshes sign-in on success.

authsystem/Controllers/AuthController.cs – adds [Authorize] POST api/auth/change-password that reads userId via _userManager.GetUserId(User) and calls the service.

### **Why**

Provide a secure, authenticated password change flow.

### **API Contract**

POST /api/auth/change-password
Body: { currentPassword, newPassword, confirmNewPassword }
200 OK: { "message": "Password changed successfully." }
400 BadRequest: { "error": "<reason from Identity>" }
401 Unauthorized: if not signed in.

### **Impact**

No breaking changes to existing endpoints.