### PR TITLE
Be/272 som användare vill jag få tydlig feedback om e post redan används vid registrering så att jag kan välja en annan

### DIFF
--- a/Infrastructure/Services/AuthService.cs
+++ b/Infrastructure/Services/AuthService.cs
@@ -22,6 +22,18 @@ public class AuthService(UserManager<ApplicationUser> userManager,
             UserName = request.Email
         };
 
+        var emailExists = await ExistsEmailAsync(request.Email);
+        
+        if (!emailExists.Succeeded)
+        {
+            return new AuthServiceResult
+            {
+                Succeeded = false,
+                Error = "Email already exists",
+                Message = "This email address is already taken."
+            };
+        }
+
         if (request.Password != request.ConfirmedPassword)
         {
             return new AuthServiceResult
@@ -100,5 +112,30 @@ public class AuthService(UserManager<ApplicationUser> userManager,
         await _signInManager.RefreshSignInAsync(user);
 
         return new AuthServiceResult { Succeeded = true, Message = "Password changed successfully." };
+    }
+
+    /// <summary>
+    /// Checks if an email already exists in the database
+    /// </summary>
+    /// <param name="email">Email</param>
+    /// <returns>Succeeded false = email exists, true= email free</returns>
+    public async Task<AuthServiceResult> ExistsEmailAsync(string email)
+    {
+        var user = await _userManager.FindByEmailAsync(email);
+
+        if (user is not null)
+        {
+            return new AuthServiceResult
+            {
+                Succeeded = false,
+                Error = "Email already exists."
+            };
+        }
+
+        return new AuthServiceResult
+        {
+            Succeeded = true,
+            Message = "Email is available."
+        };
     }
 }


### PR DESCRIPTION
### **What’s Changed**

Added method ExistsEmailAsync(string email) in AuthService.

Returns Succeeded = false if the email already exists.

Returns Succeeded = true if the email is available.

Updated RegisterAsync to prevent registration when the email already exists.

Improved error handling in registration:

Clear error message when the email is already taken.

Consistent handling of password confirmation.

 ### **Usefulness**

Previously, users could attempt to register with an email that was already in use, which resulted in a poor user experience and unclear errors.

Registration is now blocked immediately with a clear error message when the email is taken.

### **Testing**

 Tried registering with a new email → success 

 Tried registering with an existing email → blocked with error 

 Tried with mismatched password and confirmed password → validation works as expected 