### PR TITLE
Add profile DTOs + service methods for “My Profile” (backend-only, service-first)

### DIFF
--- a/Infrastructure/Dtos/UpdateProfileRequest.cs
+++ b/Infrastructure/Dtos/UpdateProfileRequest.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Infrastructure.Dtos;
+
+public class UpdateProfileRequest
+{
+    [Required, MinLength(2), MaxLength(50)]
+    public string Firstname { get; set; } = null!;
+
+    [Required, MinLength(2), MaxLength(50)]
+    public string Lastname { get; set; } = null!;
+
+    [Phone]
+    public string? PhoneNumber { get; set; }
+}

--- a/Infrastructure/Dtos/UserProfileDto.cs
+++ b/Infrastructure/Dtos/UserProfileDto.cs
@@ -1,0 +1,10 @@
+﻿namespace Infrastructure.Dtos;
+
+public record UserProfileDto
+{
+    public string Id { get; init; } = null!;
+    public string Firstname { get; init; } = null!;
+    public string Lastname { get; init; } = null!;
+    public string Email { get; init; } = null!;
+    public string? PhoneNumber { get; init; }
+}

--- a/Infrastructure/Interfaces/IAuthService.cs
+++ b/Infrastructure/Interfaces/IAuthService.cs
@@ -1,4 +1,5 @@
-﻿using Infrastructure.Dtos;
+﻿using System.Security.Claims;
+using Infrastructure.Dtos;
 using Infrastructure.Models;
 
 namespace Infrastructure.Interfaces;
@@ -11,4 +12,7 @@ public interface IAuthService
     Task<AuthServiceResult> LoginAsync(LoginRequest request);
 
     Task<AuthServiceResult> ChangePasswordAsync(string userId, ChangePasswordRequest request);
+
+    Task<AuthServiceResult<UserProfileDto>> GetMyProfileAsync(ClaimsPrincipal user);
+    Task<AuthServiceResult<UserProfileDto>> UpdateMyProfileAsync(ClaimsPrincipal user, UpdateProfileRequest request);
 }

--- a/Infrastructure/Models/AuthServiceResult.cs
+++ b/Infrastructure/Models/AuthServiceResult.cs
@@ -15,3 +15,8 @@ public class AuthServiceResult
     public string? Token { get; set; }
 
 }
+
+public class AuthServiceResult<T> : AuthServiceResult
+{
+    public T? Data { get; set; }
+}


### PR DESCRIPTION
### **Summary**

Implements the backend core for “view & update my profile” with minimal changes and all logic in the service.

### **What’s included**

**DTOs**
UserProfileDto (Id, Firstname, Lastname, Email, PhoneNumber)
UpdateProfileRequest (Firstname, Lastname, PhoneNumber) with validation

**Result model**
AuthServiceResult<T> (generic variant) to return data from service methods

**IAuthService**
GetMyProfileAsync(ClaimsPrincipal user)
UpdateMyProfileAsync(ClaimsPrincipal user, UpdateProfileRequest request)

**AuthService implementation**
Reads the current user from JWT/Identity (UserManager.GetUserAsync(userClaims))
Updates Firstname/Lastname/PhoneNumber via UserManager.UpdateAsync
Returns only non-sensitive fields (no password/hash/etc.)
Success message: “Ändringarna är sparade”

### **Impact**

No breaking changes to existing endpoints.
No changes required in Program.cs.

_Controller endpoints can now be added trivially:_
GET /api/auth/me → _authService.GetMyProfileAsync(User)
PUT /api/auth/me → _authService.UpdateMyProfileAsync(User, request)